### PR TITLE
add go realeser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Go Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: useblacksmith/setup-go@v6
+        with:
+          go-version: "1.24.1"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+bin/
+local/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,57 @@
+project_name: hyde-ipc
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+    main: ./cmd/main.go
+    binary: "hyde-ipc-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      # - LICENSE # TODO: add license
+      - README.md
+
+nfpms:
+  - vendor: "hyde-ipc"
+    homepage: "https://github.com/HyDE-Project/hyde-ipc"
+    maintainer: "HyDE-Project"
+    description: "A lightweight event handler for Hyprland that executes custom scripts based on Hyprland IPC events."
+    license: "MIT"
+    bindir: /usr/bin
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  github:
+    owner: HyDE-Project
+    name: hyde-ipc
+  prerelease: auto
+  draft: false


### PR DESCRIPTION
This pr adds `gorealser` + workflow file to auto generate binaries with `checksums`! 
CRUTIAL since it really is "sus" to just put a binary in `HyDE` without any traces!

https://github.com/HyDE-Project/HyDE/commit/5c4221ff63872eb8076d4f593caa0252d5572d5c